### PR TITLE
Simulate

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -138,7 +138,6 @@ An important concept in the VM is that each instruction has a specific "cycle co
   - `drive`: 2 cycles
   - `fire`: 3 cycles
   - `scan`: 3 cycles
-  - `attack`: 5 cycles
 - **Control Flow**:
   - `call` and `ret`: 3 cycles
   - Jump instructions: 1 cycle
@@ -479,7 +478,6 @@ flowchart LR
     
     TURRET --> TURRET_OPS[Turret Operations]
     TURRET_OPS --> ROTATE_TURRET[rotate]
-    TURRET_OPS --> ATTACK[attack]
     TURRET_OPS --> FIRE[fire]
     TURRET_OPS --> SCAN[scan]
 ```
@@ -490,7 +488,6 @@ flowchart LR
 | `deselect` | Deselect current component | None | 1 | None | `@component` = 0 |
 | `rotate <operand>` | Request rotation for selected component | Angle delta (degrees) | 3 | Any | Component begins rotating (applies to selected component) |
 | `drive <operand>` | Set drive velocity | Target velocity | 2 | Drive (ID 1) | Drive begins accelerating/decelerating |
-| `attack` | Perform melee attack | None | 5 | Turret (ID 2) | Initiates melee attack |
 | `fire <operand>` | Fire ranged weapon | Power level (0.0-1.0) | 3 | Turret (ID 2) | Fires projectile |
 | `scan` | Scan for targets | None | 3 | Turret (ID 2) | Updates `@target_distance` and `@target_angle` |
 
@@ -584,8 +581,7 @@ Robots have two main components, each with different capabilities:
 
 2. **Turret** (ID 2): Controls weapons and scanning
    - `rotate`: Change direction
-   - `attack`: Melee attack
-   - `fire`: Range attack
+   - `fire`: Fire projectile
    - `scan`: Detect other robots
 
 Before using any component-specific instruction, you must first select the appropriate component using the `select` instruction:

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -139,7 +139,7 @@ An important concept in the VM is that each instruction has a specific "cycle co
   - `fire`: 3 cycles
   - `scan`: 3 cycles
 - **Control Flow**:
-  - `call` and `ret`: 3 cycles
+  - `call` and `ret`: 2 cycles
   - Jump instructions: 1 cycle
 
 This means a complex instruction like `fire` will take 3 simulation cycles to complete before the VM moves on to the next instruction. During this time, other robots will continue executing their own instructions.
@@ -184,48 +184,46 @@ Registers are special storage locations that hold data values. The VM has severa
 ### General Purpose Data Registers
 These registers can be both read from and written to for general-purpose storage:
 
-| Register | Description | Read/Write |
-|----------|-------------|------------|
-| `@d0` - `@d18` | General purpose data registers | Read/Write |
-| `@c` | Counter register (used with `loop` instruction) | Read/Write |
-| `@index` | Memory index register (used with `lod` and `sto` instructions) | Read/Write |
+| Register       | Description                                                    | Read/Write |
+|----------------|----------------------------------------------------------------|------------|
+| `@d0` - `@d18` | General purpose data registers                                 | Read/Write |
+| `@c`           | Counter register (used with `loop` instruction)                | Read/Write |
+| `@index`       | Memory index register (used with `lod` and `sto` instructions) | Read/Write |
 
 ### Status Registers
 These provide information about the VM state:
 
-| Register | Description | Read/Write |
-|----------|-------------|------------|
-| `@result` | Result of the last `cmp` operation | Read/Write |
-| `@fault` | Error code if a VM fault occurs | Read-only |
-| `@turn` | Current simulation turn number | Read-only |
-| `@cycle` | Current execution cycle within the turn | Read-only |
-| `@rand` | Random value between 0.0 and 1.0 | Read-only |
+| Register  | Description                             | Read/Write |
+|-----------|-----------------------------------------|------------|
+| `@result` | Result of the last `cmp` operation      | Read/Write |
+| `@fault`  | Error code if a VM fault occurs         | Read-only  |
+| `@turn`   | Current simulation turn number          | Read-only  |
+| `@cycle`  | Current execution cycle within the turn | Read-only  |
+| `@rand`   | Random value between 0.0 and 1.0        | Read-only  |
 
 ### Robot Status Registers
 These provide information about the robot's current state:
 
-| Register | Description | Read/Write |
-|----------|-------------|------------|
-| `@health` | Current health points | Read-only |
-| `@power` | Current energy/power level | Read-only |
-| `@posx` / `@pos_x` | Robot's X coordinate | Read-only |
-| `@posy` / `@pos_y` | Robot's Y coordinate | Read-only |
-| `@component` | ID of currently selected component | Read-only (set only by `select`/`deselect` instructions) |
+| Register           | Description                        | Read/Write                                               |
+|--------------------|------------------------------------|----------------------------------------------------------|
+| `@health`          | Current health points              | Read-only                                                |
+| `@power`           | Current energy/power level         | Read-only                                                |
+| `@posx` / `@pos_x` | Robot's X coordinate               | Read-only                                                |
+| `@posy` / `@pos_y` | Robot's Y coordinate               | Read-only                                                |
+| `@component`       | ID of currently selected component | Read-only (set only by `select`/`deselect` instructions) |
 
 ### Component Status Registers
 These provide information about the currently selected component:
 
-| Register | Description | Read/Write |
-|----------|-------------|------------|
-| `@drive_direction` | Direction the drive component is facing (degrees) | Read-only |
-| `@drive_velocity` | Speed the drive component is moving at (units/cycle) | Read-only |
-| `@turret_direction` | Direction the selected turret is facing (degrees) | Read-only |
-| `@forward_distance` | Distance to obstacle in front of the drive | Read-only |
-| `@backward_distance` | Distance to obstacle behind the drive | Read-only |
-| `@weapon_power` | Power setting of the selected weapon | Read-only |
-| `@weapon_cooldown` | Remaining cooldown cycles for the selected weapon | Read-only |
-| `@target_distance` | Distance to the last detected target from the selected scanner | Read-only |
-| `@target_direction` | Absolute angle to the last detected target from the selected scanner (degrees) | Read-only |
+| Register             | Description                                                                    | Read/Write |
+|----------------------|--------------------------------------------------------------------------------|------------|
+| `@drive_direction`   | Direction the drive component is facing (degrees)                              | Read-only  |
+| `@drive_velocity`    | Speed the drive component is moving at (units/cycle)                           | Read-only  |
+| `@turret_direction`  | Direction the selected turret is facing (degrees)                              | Read-only  |
+| `@forward_distance`  | Distance to obstacle in front of the drive                                     | Read-only  |
+| `@backward_distance` | Distance to obstacle behind the drive                                          | Read-only  |
+| `@target_distance`   | Distance to the last detected target from the selected scanner                 | Read-only  |
+| `@target_direction`  | Absolute angle to the last detected target from the selected scanner (degrees) | Read-only  |
 
 ## Instructions
 
@@ -289,29 +287,29 @@ flowchart TD
 
 ### Stack Operations
 
-| Instruction | Description | Operands | VM Cycle Cost | Stack/Register Effects |
-|-------------|-------------|----------|---------------|------------------------|
-| `push <operand>` | Push a value onto the stack | Value or register | 1 | Stack: +1 item |
-| `pop <register>` | Pop a value from stack into register | Register | 1 | Stack: -1 item, Register: written |
-| `pop` | Pop and discard value from stack | None | 1 | Stack: -1 item |
-| `dup` | Duplicate top value on stack | None | 1 | Stack: +1 item (copy of top) |
-| `swap` | Swap top two values on stack | None | 1 | Stack: rearranged |
+| Instruction      | Description                          | Operands          | VM Cycle Cost | Stack/Register Effects            |
+|------------------|--------------------------------------|-------------------|---------------|-----------------------------------|
+| `push <operand>` | Push a value onto the stack          | Value or register | 1             | Stack: +1 item                    |
+| `pop <register>` | Pop a value from stack into register | Register          | 1             | Stack: -1 item, Register: written |
+| `pop`            | Pop and discard value from stack     | None              | 1             | Stack: -1 item                    |
+| `dup`            | Duplicate top value on stack         | None              | 1             | Stack: +1 item (copy of top)      |
+| `swap`           | Swap top two values on stack         | None              | 1             | Stack: rearranged                 |
 
 ### Register Operations
 
-| Instruction | Description | Operands | VM Cycle Cost | Stack/Register Effects |
-|-------------|-------------|----------|---------------|------------------------|
-| `mov <register> <operand>` | Copy value to register | Register, Value/Register | 1 | Register: written |
-| `cmp <operand1> <operand2>` | Compare values, store result | Two values/registers | 1 | `@result`: written |
+| Instruction                 | Description                  | Operands                 | VM Cycle Cost | Stack/Register Effects |
+|-----------------------------|------------------------------|--------------------------|---------------|------------------------|
+| `mov <register> <operand>`  | Copy value to register       | Register, Value/Register | 1             | Register: written      |
+| `cmp <operand1> <operand2>` | Compare values, store result | Two values/registers     | 1             | `@result`: written     |
 
 ### Memory Operations
 
 Memory operations allow your robot to store and retrieve values from a memory array, providing more storage beyond the limited number of registers. The VM maintains a 1024-element memory array that persists throughout program execution.
 
-| Instruction | Description | Operands | VM Cycle Cost | Register Effects |
-|-------------|-------------|----------|---------------|------------------|
-| `lod <register>` | Load value from memory at `@index` position into register | Register | 1 | `@index`: auto-incremented, Register: written |
-| `sto <operand>` | Store value to memory at `@index` position | Value/Register | 1 | `@index`: auto-incremented |
+| Instruction      | Description                                               | Operands       | VM Cycle Cost | Register Effects                              |
+|------------------|-----------------------------------------------------------|----------------|---------------|-----------------------------------------------|
+| `lod <register>` | Load value from memory at `@index` position into register | Register       | 1             | `@index`: auto-incremented, Register: written |
+| `sto <operand>`  | Store value to memory at `@index` position                | Value/Register | 1             | `@index`: auto-incremented                    |
 
 Memory access is controlled via the `@index` register, which points to the current memory location (0-1023). Both `lod` and `sto` operations automatically increment `@index` after execution, making it convenient to work with consecutive memory locations.
 
@@ -359,37 +357,37 @@ Basic arithmetic operations (`add`, `sub`, `mul`, `div`, `mod`) also have an alt
   - Example: `add @d0 5` -> `@result` = value of `@d0` + 5. The stack is unchanged.
   - Example: `sub 10 @d1` -> `@result` = 10 - value of `@d1`. The stack is unchanged.
 
-| Instruction | Description (Stack Form) | Operands (Stack Form) | Stack Effect (Stack Form) | Operands (Operand Form) | Effect (Operand Form) | VM Cycle Cost |
-|-------------|----------------------------|-----------------------|---------------------------|-------------------------|-------------------------|---------------|
-| `add`       | Add top two values         | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 + op2   | 1             |
-| `sub`       | Subtract top from second   | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 - op2   | 1             |
-| `mul`       | Multiply top two values    | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 * op2   | 1             |
-| `div`       | Divide second by top       | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 / op2   | 1             |
-| `mod`       | Modulo (remainder)         | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 % op2   | 1             |
-| `divmod`    | Divide and return both quotient and remainder | None | 1 | -2, +2 items | N/A | N/A | 1 |
-| `pow`       | Exponentiation             | None                  | -2, +1 items              | `<base> <exp>`          | `@result` = base ^ exp  | 2             |
-| `sqrt`      | Square root of top value   | None                  | -1, +1 items              | `<value>`               | `@result` = sqrt(value) | 2             |
-| `log`       | Natural logarithm          | None                  | -1, +1 items              | `<value>`               | `@result` = ln(value)   | 2             |
-| `sin`       | Sine (degrees)             | None                  | -1, +1 items              | `<degrees>`             | `@result` = sin(degrees)| 2             |
-| `cos`       | Cosine (degrees)           | None                  | -1, +1 items              | `<degrees>`             | `@result` = cos(degrees)| 2             |
-| `tan`       | Tangent (degrees)          | None                  | -1, +1 items              | `<degrees>`             | `@result` = tan(degrees)| 2             |
-| `asin`      | Arc sine (result degrees)  | None                  | -1, +1 items              | `<value>`               | `@result` = asin(value) | 2             |
-| `acos`      | Arc cosine (result degrees)| None                  | -1, +1 items              | `<value>`               | `@result` = acos(value) | 2             |
-| `atan`      | Arc tangent (result degrees)| None                 | -1, +1 items              | `<value>`               | `@result` = atan(value) | 2             |
-| `atan2`     | Two-arg arc tan (result deg)| None                | -2, +1 items              | `<y> <x>`               | `@result` = atan2(y, x)| 2             |
-| `abs`       | Absolute value             | None                  | -1, +1 items              | `<value>`               | `@result` = abs(value)  | 1             |
+| Instruction | Description (Stack Form)                      | Operands (Stack Form) | Stack Effect (Stack Form) | Operands (Operand Form) | Effect (Operand Form)    | VM Cycle Cost |
+|-------------|-----------------------------------------------|-----------------------|---------------------------|-------------------------|--------------------------|---------------|
+| `add`       | Add top two values                            | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 + op2    | 1             |
+| `sub`       | Subtract top from second                      | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 - op2    | 1             |
+| `mul`       | Multiply top two values                       | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 * op2    | 1             |
+| `div`       | Divide second by top                          | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 / op2    | 1             |
+| `mod`       | Modulo (remainder)                            | None                  | -2, +1 items              | `<op1> <op2>`           | `@result` = op1 % op2    | 1             |
+| `divmod`    | Divide and return both quotient and remainder | None                  | 1                         | -2, +2 items            | N/A                      | N/A           | 1 |
+| `pow`       | Exponentiation                                | None                  | -2, +1 items              | `<base> <exp>`          | `@result` = base ^ exp   | 2             |
+| `sqrt`      | Square root of top value                      | None                  | -1, +1 items              | `<value>`               | `@result` = sqrt(value)  | 2             |
+| `log`       | Natural logarithm                             | None                  | -1, +1 items              | `<value>`               | `@result` = ln(value)    | 2             |
+| `sin`       | Sine (degrees)                                | None                  | -1, +1 items              | `<degrees>`             | `@result` = sin(degrees) | 2             |
+| `cos`       | Cosine (degrees)                              | None                  | -1, +1 items              | `<degrees>`             | `@result` = cos(degrees) | 2             |
+| `tan`       | Tangent (degrees)                             | None                  | -1, +1 items              | `<degrees>`             | `@result` = tan(degrees) | 2             |
+| `asin`      | Arc sine (result degrees)                     | None                  | -1, +1 items              | `<value>`               | `@result` = asin(value)  | 2             |
+| `acos`      | Arc cosine (result degrees)                   | None                  | -1, +1 items              | `<value>`               | `@result` = acos(value)  | 2             |
+| `atan`      | Arc tangent (result degrees)                  | None                  | -1, +1 items              | `<value>`               | `@result` = atan(value)  | 2             |
+| `atan2`     | Two-arg arc tan (result deg)                  | None                  | -2, +1 items              | `<y> <x>`               | `@result` = atan2(y, x)  | 2             |
+| `abs`       | Absolute value                                | None                  | -1, +1 items              | `<value>`               | `@result` = abs(value)   | 1             |
 
 ### Binary Operations
 These operations perform bitwise manipulations by first converting float values to 32-bit unsigned integers:
 
-| Instruction | Description | Operands | VM Cycle Cost | Stack Effect |
-|-------------|-------------|----------|---------------|--------------|
-| `and`       | Bitwise AND of top two values | None | 1 | -2, +1 items |
-| `or`        | Bitwise OR of top two values | None | 1 | -2, +1 items |
-| `xor`       | Bitwise XOR of top two values | None | 1 | -2, +1 items |
-| `not`       | Bitwise NOT of top value | None | 1 | -1, +1 items |
-| `shl`       | Shift left value by specified bits | None | 1 | -2, +1 items |
-| `shr`       | Shift right value by specified bits | None | 1 | -2, +1 items |
+| Instruction | Description                         | Operands | VM Cycle Cost | Stack Effect |
+|-------------|-------------------------------------|----------|---------------|--------------|
+| `and`       | Bitwise AND of top two values       | None     | 1             | -2, +1 items |
+| `or`        | Bitwise OR of top two values        | None     | 1             | -2, +1 items |
+| `xor`       | Bitwise XOR of top two values       | None     | 1             | -2, +1 items |
+| `not`       | Bitwise NOT of top value            | None     | 1             | -1, +1 items |
+| `shl`       | Shift left value by specified bits  | None     | 1             | -2, +1 items |
+| `shr`       | Shift right value by specified bits | None     | 1             | -2, +1 items |
 
 For binary operations, the VM:
 1. Pops the required number of values from the stack (1 for `not`, 2 for others)
@@ -412,14 +410,14 @@ Binary operations also have an alternative form with operands:
   - Example: `and @d0 5` -> `@result` = value of `@d0` & 5 (as u32). The stack is unchanged.
   - Example: `shl @d0 2` -> `@result` = value of `@d0` << 2 (shifted left 2 bits). The stack is unchanged.
 
-| Instruction | Description (Operand Form) | Operands | VM Cycle Cost | Effect |
-|-------------|----------------------------|----------|---------------|--------|
-| `and <op1> <op2>` | Bitwise AND of two operands | Two values/registers | 1 | `@result` = op1 & op2 |
-| `or <op1> <op2>` | Bitwise OR of two operands | Two values/registers | 1 | `@result` = op1 \| op2 |
-| `xor <op1> <op2>` | Bitwise XOR of two operands | Two values/registers | 1 | `@result` = op1 ^ op2 |
-| `not <op>` | Bitwise NOT of operand | Value/register | 1 | `@result` = ~op |
-| `shl <op1> <op2>` | Shift op1 left by op2 bits | Two values/registers | 1 | `@result` = op1 << op2 |
-| `shr <op1> <op2>` | Shift op1 right by op2 bits | Two values/registers | 1 | `@result` = op1 >> op2 |
+| Instruction       | Description (Operand Form)  | Operands             | VM Cycle Cost | Effect                 |
+|-------------------|-----------------------------|----------------------|---------------|------------------------|
+| `and <op1> <op2>` | Bitwise AND of two operands | Two values/registers | 1             | `@result` = op1 & op2  |
+| `or <op1> <op2>`  | Bitwise OR of two operands  | Two values/registers | 1             | `@result` = op1 \| op2 |
+| `xor <op1> <op2>` | Bitwise XOR of two operands | Two values/registers | 1             | `@result` = op1 ^ op2  |
+| `not <op>`        | Bitwise NOT of operand      | Value/register       | 1             | `@result` = ~op        |
+| `shl <op1> <op2>` | Shift op1 left by op2 bits  | Two values/registers | 1             | `@result` = op1 << op2 |
+| `shr <op1> <op2>` | Shift op1 right by op2 bits | Two values/registers | 1             | `@result` = op1 >> op2 |
 
 Example using binary operations:
 ```asm
@@ -452,18 +450,18 @@ mov @d3 @result  ; Update @d3 with the shifted value
 
 ### Control Flow
 
-| Instruction | Description | Operands | VM Cycle Cost | Effect |
-|-------------|-------------|----------|---------------|--------|
-| `jmp <label>` | Unconditional jump | Label | 1 | IP = label position |
-| `jz <label>` / `je <label>` | Jump if `@result` == 0 | Label | 1 | Conditional IP change |
-| `jnz <label>` / `jne <label>` | Jump if `@result` != 0 | Label | 1 | Conditional IP change |
-| `jl <label>` | Jump if `@result` < 0 | Label | 1 | Conditional IP change |
-| `jle <label>` | Jump if `@result` <= 0 | Label | 1 | Conditional IP change |
-| `jg <label>` | Jump if `@result` > 0 | Label | 1 | Conditional IP change |
-| `jge <label>` | Jump if `@result` >= 0 | Label | 1 | Conditional IP change |
-| `call <label>` | Call subroutine | Label | 3 | Push return address, IP = label |
-| `ret` | Return from subroutine | None | 3 | Pop return address, jump to it |
-| `loop <label>` | Decrement `@c`, jump if not zero | Label | 1 | `@c` -= 1, conditional jump |
+| Instruction                   | Description                      | Operands | VM Cycle Cost | Effect                          |
+|-------------------------------|----------------------------------|----------|---------------|---------------------------------|
+| `jmp <label>`                 | Unconditional jump               | Label    | 1             | IP = label position             |
+| `jz <label>` / `je <label>`   | Jump if `@result` == 0           | Label    | 1             | Conditional IP change           |
+| `jnz <label>` / `jne <label>` | Jump if `@result` != 0           | Label    | 1             | Conditional IP change           |
+| `jl <label>`                  | Jump if `@result` < 0            | Label    | 1             | Conditional IP change           |
+| `jle <label>`                 | Jump if `@result` <= 0           | Label    | 1             | Conditional IP change           |
+| `jg <label>`                  | Jump if `@result` > 0            | Label    | 1             | Conditional IP change           |
+| `jge <label>`                 | Jump if `@result` >= 0           | Label    | 1             | Conditional IP change           |
+| `call <label>`                | Call subroutine                  | Label    | 2             | Push return address, IP = label |
+| `ret`                         | Return from subroutine           | None     | 2             | Pop return address, jump to it  |
+| `loop <label>`                | Decrement `@c`, jump if not zero | Label    | 1             | `@c` -= 1, conditional jump     |
 
 ### Component Control
 
@@ -482,22 +480,22 @@ flowchart LR
     TURRET_OPS --> SCAN[scan]
 ```
 
-| Instruction | Description | Operands | VM Cycle Cost | Required Component | Effect |
-|-------------|-------------|----------|---------------|-------------------|--------|
-| `select <operand>` | Select component by ID | Component ID or register | 1 | None | `@component` = component ID |
-| `deselect` | Deselect current component | None | 1 | None | `@component` = 0 |
-| `rotate <operand>` | Request rotation for selected component | Angle delta (degrees) | 3 | Any | Component begins rotating (applies to selected component) |
-| `drive <operand>` | Set drive velocity | Target velocity | 2 | Drive (ID 1) | Drive begins accelerating/decelerating |
-| `fire <operand>` | Fire ranged weapon | Power level (0.0-1.0) | 3 | Turret (ID 2) | Fires projectile |
-| `scan` | Scan for targets | None | 3 | Turret (ID 2) | Updates `@target_distance` and `@target_angle` |
+| Instruction        | Description                             | Operands                 | VM Cycle Cost | Required Component | Effect                                                                             |
+|--------------------|-----------------------------------------|--------------------------|---------------|--------------------|------------------------------------------------------------------------------------|
+| `select <operand>` | Select component by ID                  | Component ID or register | 1             | None               | `@component` = component ID                                                        |
+| `deselect`         | Deselect current component              | None                     | 1             | None               | `@component` = 0                                                                   |
+| `rotate <operand>` | Request rotation for selected component | Angle delta (degrees)    | variable      | Any                | Component begins rotating (applies to selected component); cost is 1 cycle per 45° |
+| `drive <operand>`  | Set drive velocity                      | Target velocity          | 1             | Drive (ID 1)       | Drive begins accelerating/decelerating                                             |
+| `fire <operand>`   | Fire ranged weapon                      | Power level (0.0-1.0)    | 3             | Turret (ID 2)      | Fires projectile                                                                   |
+| `scan`             | Scan for targets                        | None                     | 1             | Turret (ID 2)      | Updates `@target_distance` and `@target_angle`                                     |
 
 ### Miscellaneous
 
-| Instruction | Description | Operands | VM Cycle Cost | Effect |
-|-------------|-------------|----------|---------------|--------|
-| `nop` | No operation | None | 1 | None (wastes a cycle) |
-| `dbg <operand>` | Print debug value | Value or register | 1 | Outputs value to console |
-| `sleep <cycles>` | Pause execution for the given number of cycles | Value, register, or constant | cycles | Pauses execution for the specified number of cycles |
+| Instruction      | Description                                    | Operands                     | VM Cycle Cost | Effect                                                                   |
+|------------------|------------------------------------------------|------------------------------|---------------|--------------------------------------------------------------------------|
+| `nop`            | No operation                                   | None                         | 1             | None (wastes a cycle)                                                    |
+| `dbg <operand>`  | Print debug value                              | Value or register            | 1             | Outputs value to console                                                 |
+| `sleep <cycles>` | Pause execution for the given number of cycles | Value, register, or constant | variable      | Pauses execution for the specified number of cycles; cost is the operand |
 
 ## Constants
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -134,8 +134,8 @@ An important concept in the VM is that each instruction has a specific "cycle co
 - **Basic Operations** (push, pop, mov, stack operations): 1 cycle
 - **Math Operations** (pow, sqrt, trigonometric functions): 2 cycles
 - **Component Operations**:
-  - `rotate`: 3 cycles
-  - `drive`: 2 cycles
+  - `rotate`: 2 cycles
+  - `drive`: 1 cycle
   - `fire`: 3 cycles
   - `scan`: 3 cycles
 - **Control Flow**:
@@ -158,7 +158,7 @@ Example:
 start:                ; Label
     mov @d0 0.0       ; Initialize @d0 to 0 (1 cycle)
     select 1          ; Select drive component (1 cycle)
-    drive MAX_SPEED   ; Set drive speed using constant (2 cycles)
+    drive MAX_SPEED   ; Set drive speed using constant (1 cycle) - max speed = 5 grid units/turn
     jmp start         ; Jump back to start (1 cycle)
 ```
 
@@ -484,10 +484,29 @@ flowchart LR
 |--------------------|-----------------------------------------|--------------------------|---------------|--------------------|------------------------------------------------------------------------------------|
 | `select <operand>` | Select component by ID                  | Component ID or register | 1             | None               | `@component` = component ID                                                        |
 | `deselect`         | Deselect current component              | None                     | 1             | None               | `@component` = 0                                                                   |
-| `rotate <operand>` | Request rotation for selected component | Angle delta (degrees)    | variable      | Any                | Component begins rotating (applies to selected component); cost is 1 cycle per 45° |
+| `rotate <operand>` | Request rotation for selected component | Angle delta (degrees)    | 2             | Any                | Component begins rotating (applies to selected component)                          |
 | `drive <operand>`  | Set drive velocity                      | Target velocity          | 1             | Drive (ID 1)       | Drive begins accelerating/decelerating                                             |
 | `fire <operand>`   | Fire ranged weapon                      | Power level (0.0-1.0)    | 3             | Turret (ID 2)      | Fires projectile                                                                   |
-| `scan`             | Scan for targets                        | None                     | 1             | Turret (ID 2)      | Updates `@target_distance` and `@target_angle`                                     |
+| `scan`             | Scan for targets                        | None                     | 3             | Turret (ID 2)      | Updates `@target_distance` and `@target_angle`                                     |
+
+### Drive Speed System
+
+The `drive` instruction uses a **normalized speed system** ranging from 0.0 to 1.0:
+
+- **0.0**: No movement (stopped)
+- **0.2**: 20% of max speed = 1.0 grid unit per turn
+- **0.5**: 50% of max speed = 2.5 grid units per turn  
+- **1.0**: 100% of max speed = 5.0 grid units per turn (25% of arena width)
+
+**Speed Examples:**
+```asm
+drive 0.0    ; Stop
+drive 0.2    ; Slow movement (1 grid unit/turn) 
+drive 0.5    ; Medium movement (2.5 grid units/turn)
+drive 1.0    ; Maximum movement (5 grid units/turn)
+```
+
+Since the arena is 20×20 grid units, a speed of 1.0 allows the robot to cross 25% of the arena in one turn. Speed values above 1.0 are automatically clamped to 1.0, and negative values work for reverse movement.
 
 ### Miscellaneous
 
@@ -537,8 +556,46 @@ The following constants are predefined and available to all robot programs:
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `ARENA_WIDTH` | Width of arena | Total width of the arena grid (typically 20.0) |
-| `ARENA_HEIGHT` | Height of arena | Total height of the arena grid (typically 15.0) |
+| `ARENA_WIDTH` | 20.0 | Total width of the arena in grid units |
+| `ARENA_HEIGHT` | 20.0 | Total height of the arena in grid units |
+
+### Arena Coordinate System
+
+The Bot Arena uses a dual coordinate system that's important to understand:
+
+**Coordinate Units (0.0 → 1.0):**
+- The arena spans from 0.0 to 1.0 in both X and Y dimensions
+- Robot position registers (`@posx`, `@posy`) return values in this range
+- Internal physics calculations use coordinate units
+
+**Grid Units (0 → 20):**
+- The arena is divided into a 20×20 grid of tiles
+- Each grid unit represents 5% (0.05) of the arena's width and height
+- Constants `ARENA_WIDTH` and `ARENA_HEIGHT` are expressed in grid units
+- Movement speeds and distances are typically expressed in grid units
+
+**Conversion:**
+- 1 grid unit = 0.05 coordinate units
+- 20 grid units = 1.0 coordinate unit (full arena dimension)
+- Robot at position (10, 10) in grid units = (0.5, 0.5) in coordinate units (center)
+
+**Example:**
+```asm
+; Drive at 1 grid unit per turn (5% of arena width)
+drive 1.0
+
+; Current position in coordinate units (0.0-1.0 range)
+mov @d0 @posx    ; e.g., 0.25 = 25% across the arena
+mov @d1 @posy    ; e.g., 0.75 = 75% down the arena
+
+; Convert coordinate units to grid units for logic
+mul @d0 ARENA_WIDTH  ; @result = 0.25 * 20 = 5.0 (grid unit X)
+mov @d2 @result
+mul @d1 ARENA_HEIGHT ; @result = 0.75 * 20 = 15.0 (grid unit Y) 
+mov @d3 @result
+```
+
+The rendering system scales these coordinates to the actual pixel dimensions of the display, but this is transparent to the robot programs.
 
 ## Stack Operations
 
@@ -586,7 +643,7 @@ Before using any component-specific instruction, you must first select the appro
 
 ```asm
 select 1       ; Select the drive component
-drive 0.5      ; Set drive velocity to 0.5 units/cycle
+drive 0.5      ; Set drive velocity to 50% of max speed (2.5 grid units/turn)
 rotate 45.0    ; Begin rotating the drive 45 degrees
 
 select 2       ; Select the turret component
@@ -608,7 +665,7 @@ This program makes the robot move in a square pattern:
 select DRIVE_ID             ; Select drive component
 
 start:
-    drive 2.0               ; Move forward
+    drive 0.4               ; Move forward at 40% speed (2 grid units/turn)
     sleep DRIVE_DELAY       ; Wait DRIVE_DELAY cycles
     drive 0.0               ; Stop
     rotate 90.0             ; Turn 90 degrees
@@ -660,7 +717,7 @@ start:
         ; Move in the direction specified by @d5
         select DRIVE_ID
         rotate @d5
-        drive 0.5
+        drive 0.1            ; Move at 10% speed (0.5 grid units/turn)
         
         ; Wait for movement to complete
         sleep 10
@@ -924,7 +981,7 @@ main_loop:
 zigzag:
     push @d4
     select DRIVE_ID
-    drive 0.5
+    drive 0.1            ; Move at 10% speed (0.5 grid units/turn)
     push @d0
     push 180.0
     mul

--- a/bots/jojo.rasm
+++ b/bots/jojo.rasm
@@ -3,7 +3,7 @@
 
 .const DRIVE_ID 1
 .const TURRET_ID 2
-.const DRIVE_SPEED 2.0
+.const DRIVE_SPEED 1.0
 .const FIRE_POWER 1.0
 .const ARRIVAL_THRESHOLD 0.1
 .const WEAVE_STATE_INDEX 0

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,6 +5,8 @@ use crate::particles::ParticleSystem;
 use crate::robot::{Robot, RobotStatus};
 use crate::types::*;
 use ::rand::prelude::*;
+use ::rand::rngs::StdRng;
+use ::rand::SeedableRng;
 use macroquad::prelude::*;
 use macroquad::prelude::{ORANGE, SKYBLUE, Vec2, YELLOW};
 
@@ -42,9 +44,15 @@ impl Arena {
         }
     }
 
-    // Places obstacles randomly based on configured density
-    pub fn place_obstacles(&mut self) {
-        let mut rng = thread_rng();
+    // Places obstacles randomly based on configured density with optional seed for deterministic placement
+    pub fn place_obstacles_with_seed(&mut self, seed: Option<u64>) {
+        // Create RNG - either seeded or using thread_rng
+        let mut rng: Box<dyn RngCore> = if let Some(seed_value) = seed {
+            Box::new(StdRng::seed_from_u64(seed_value))
+        } else {
+            Box::new(thread_rng())
+        };
+
         let total_cells = self.grid_width * self.grid_height;
         let num_obstacles = (total_cells as f32 * OBSTACLE_DENSITY).floor() as u32;
 
@@ -388,13 +396,6 @@ impl Arena {
                 }
             }
         }
-    }
-
-    /// Adds an obstacle at the given robot's position (for wreckage)
-    pub fn add_obstacle_at_robot(&mut self, robot: &Robot) {
-        self.obstacles.push(Obstacle {
-            position: robot.position,
-        });
     }
 
     /// Adds an obstacle at the given position

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -4,9 +4,9 @@ use crate::config::*;
 use crate::particles::ParticleSystem;
 use crate::robot::{Robot, RobotStatus};
 use crate::types::*;
+use ::rand::SeedableRng;
 use ::rand::prelude::*;
 use ::rand::rngs::StdRng;
-use ::rand::SeedableRng;
 use macroquad::prelude::*;
 use macroquad::prelude::{ORANGE, SKYBLUE, Vec2, YELLOW};
 
@@ -515,9 +515,21 @@ mod tests {
         let robot1_start = Point { x: 0.25, y: 0.5 };
         let robot2_start = Point { x: 0.75, y: 0.5 };
         let arena_center = Point { x: 0.5, y: 0.5 }; // Define center point
-        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center, None);
+        let mut robot1 = Robot::new(
+            1,
+            "TestRobot1".to_string(),
+            robot1_start,
+            arena_center,
+            None,
+        );
         robot1.status = RobotStatus::Active; // Manually set active for test
-        let mut robot2 = Robot::new(2, "TestRobot2".to_string(), robot2_start, arena_center, None);
+        let mut robot2 = Robot::new(
+            2,
+            "TestRobot2".to_string(),
+            robot2_start,
+            arena_center,
+            None,
+        );
         robot2.status = RobotStatus::Active; // <-- Manually set status for test
         let mut particle_system = ParticleSystem::new(); // <-- Create dummy particle system
         let audio_manager = AudioManager::new(); // <-- Create dummy manager
@@ -608,7 +620,13 @@ mod tests {
         let mut arena = Arena::new();
         let robot1_start = Point { x: 0.5, y: 0.5 };
         let arena_center = Point { x: 0.5, y: 0.5 }; // Define center point
-        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center, None);
+        let mut robot1 = Robot::new(
+            1,
+            "TestRobot1".to_string(),
+            robot1_start,
+            arena_center,
+            None,
+        );
         robot1.status = RobotStatus::Active; // Set active
         let mut particle_system = ParticleSystem::new(); // <-- Create dummy particle system
         let audio_manager = AudioManager::new(); // <-- Create dummy manager

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -396,6 +396,11 @@ impl Arena {
             position: robot.position,
         });
     }
+
+    /// Adds an obstacle at the given position
+    pub fn add_obstacle_at_position(&mut self, position: Point) {
+        self.obstacles.push(Obstacle { position });
+    }
 }
 
 // Default implementation for Arena
@@ -509,9 +514,9 @@ mod tests {
         let robot1_start = Point { x: 0.25, y: 0.5 };
         let robot2_start = Point { x: 0.75, y: 0.5 };
         let arena_center = Point { x: 0.5, y: 0.5 }; // Define center point
-        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center);
+        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center, None);
         robot1.status = RobotStatus::Active; // Manually set active for test
-        let mut robot2 = Robot::new(2, "TestRobot2".to_string(), robot2_start, arena_center);
+        let mut robot2 = Robot::new(2, "TestRobot2".to_string(), robot2_start, arena_center, None);
         robot2.status = RobotStatus::Active; // <-- Manually set status for test
         let mut particle_system = ParticleSystem::new(); // <-- Create dummy particle system
         let audio_manager = AudioManager::new(); // <-- Create dummy manager
@@ -602,7 +607,7 @@ mod tests {
         let mut arena = Arena::new();
         let robot1_start = Point { x: 0.5, y: 0.5 };
         let arena_center = Point { x: 0.5, y: 0.5 }; // Define center point
-        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center);
+        let mut robot1 = Robot::new(1, "TestRobot1".to_string(), robot1_start, arena_center, None);
         robot1.status = RobotStatus::Active; // Set active
         let mut particle_system = ParticleSystem::new(); // <-- Create dummy particle system
         let audio_manager = AudioManager::new(); // <-- Create dummy manager

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,8 @@ pub const DEFAULT_INITIAL_HEALTH: f64 = 100.0;
 pub const DEFAULT_INITIAL_POWER: f64 = 1.0;
 
 // Robot Physics/Movement Configuration
-pub const MAX_DRIVE_UNITS_PER_TURN: f64 = 5.0;
+pub const MAX_DRIVE_SPEED_NORMALIZED: f64 = 1.0; // Maximum normalized speed (0.0 to 1.0)
+pub const MAX_DRIVE_UNITS_PER_TURN: f64 = 5.0; // Actual grid units per turn at max speed
 pub const DRIVE_VELOCITY_FACTOR: f64 = UNIT_SIZE / CYCLES_PER_TURN as f64;
 pub const MAX_ROTATION_PER_CYCLE: f64 = 90.0 / CYCLES_PER_TURN as f64; // Degrees/cycle (scaled automatically, e.g., 3.6 deg/cycle for 100 cycles/turn)
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -21,6 +21,7 @@ pub struct Game {
     pub current_turn: u32,
     pub current_cycle: u32,
     pub max_turns: u32,
+    pub seed: Option<u64>,  // Store the seed for deterministic operations
     time_accumulator: f32,
     cycle_duration: f32,
     game_over: bool,
@@ -144,11 +145,19 @@ impl Game {
             current_turn: 1,
             current_cycle: 0,
             max_turns,
+            seed,
             time_accumulator: 0.0,
             cycle_duration: 1.0 / config::CYCLES_PER_TURN as f32,
             game_over: false,
             winner: None,
         })
+    }
+
+    /// Place obstacles in the arena using the stored seed for deterministic placement
+    pub fn place_obstacles(&mut self) {
+        // For obstacle placement, use a derived seed to avoid affecting robot RNG sequences
+        let obstacle_seed = self.seed.map(|s| s.wrapping_mul(31).wrapping_add(12345));
+        self.arena.place_obstacles_with_seed(obstacle_seed);
     }
 
     /// Run the main game loop using the provided renderer
@@ -482,6 +491,7 @@ mod tests {
             current_turn: 1,
             current_cycle: 0,
             max_turns: 10,
+            seed: None,
             time_accumulator: 0.0,
             cycle_duration: 1.0,
             game_over: false,
@@ -515,6 +525,7 @@ mod tests {
             current_turn: 1,
             current_cycle: 0,
             max_turns: 10,
+            seed: None,
             time_accumulator: 0.0,
             cycle_duration: 1.0,
             game_over: false,
@@ -533,6 +544,7 @@ mod tests {
             current_turn: 1,
             current_cycle: 0,
             max_turns: 10,
+            seed: None,
             time_accumulator: 0.0,
             cycle_duration: 1.0,
             game_over: false,

--- a/src/game.rs
+++ b/src/game.rs
@@ -21,7 +21,7 @@ pub struct Game {
     pub current_turn: u32,
     pub current_cycle: u32,
     pub max_turns: u32,
-    pub seed: Option<u64>,  // Store the seed for deterministic operations
+    pub seed: Option<u64>, // Store the seed for deterministic operations
     time_accumulator: f32,
     cycle_duration: f32,
     game_over: bool,
@@ -352,12 +352,12 @@ impl Game {
             .filter(|r| r.status == RobotStatus::Destroyed)
             .map(|r| r.position)
             .collect();
-        
+
         // Add obstacles at destroyed robot positions
         for position in destroyed_robot_positions {
             self.arena.add_obstacle_at_position(position);
         }
-        
+
         // Remove destroyed robots from the robots vector
         self.robots.retain(|r| r.status != RobotStatus::Destroyed);
 
@@ -428,7 +428,7 @@ impl Game {
             // Run a full turn (all cycles)
             for _ in 0..config::CYCLES_PER_TURN {
                 self.update_simulation();
-                
+
                 // Break early if game ends mid-turn
                 if self.game_over {
                     break;
@@ -444,14 +444,25 @@ impl Game {
             .collect();
 
         match alive_robots.len() {
-            0 => info!("Simulation complete: DRAW - No survivors after {} turns", self.current_turn - 1),
+            0 => info!(
+                "Simulation complete: DRAW - No survivors after {} turns",
+                self.current_turn - 1
+            ),
             1 => {
                 let winner = alive_robots[0];
-                info!("Simulation complete: {} WINS with {:.2} health after {} turns", 
-                      winner.name, winner.health, self.current_turn - 1);
+                info!(
+                    "Simulation complete: {} WINS with {:.2} health after {} turns",
+                    winner.name,
+                    winner.health,
+                    self.current_turn - 1
+                );
             }
             _ => {
-                info!("Simulation complete: {} survivors after {} turns:", alive_robots.len(), self.current_turn - 1);
+                info!(
+                    "Simulation complete: {} survivors after {} turns:",
+                    alive_robots.len(),
+                    self.current_turn - 1
+                );
                 for robot in &alive_robots {
                     info!("  {} - Health: {:.2}", robot.name, robot.health);
                 }
@@ -473,7 +484,13 @@ mod tests {
     fn dummy_robot(id: u32, pos: Point, status: RobotStatus) -> Robot {
         // Use a default center for dummy robots in tests
         let center = Point { x: 0.5, y: 0.5 };
-        let mut robot = Robot::new(id, format!("TestRobot_{}", id).to_string(), pos, center, None);
+        let mut robot = Robot::new(
+            id,
+            format!("TestRobot_{}", id).to_string(),
+            pos,
+            center,
+            None,
+        );
         robot.status = status;
         robot
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -33,6 +33,7 @@ impl Game {
         robot_files: &[String],
         max_turns: u32,
         audio_manager: AudioManager,
+        seed: Option<u64>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // Create arena
         let arena = Arena::new();
@@ -56,6 +57,11 @@ impl Game {
         // Load robots
         let mut robots = Vec::with_capacity(num_robots);
         info!("Simulating for a maximum of {} turns.", max_turns);
+
+        // Log seed information
+        if let Some(seed_value) = seed {
+            info!("Using deterministic seed: {}", seed_value);
+        }
 
         // Define starting positions
         let offset = 2.0 * config::UNIT_SIZE;
@@ -109,7 +115,9 @@ impl Game {
             // Parse the program using the predefined constants
             match crate::vm::parser::parse_assembly(&program_content, Some(&predefined_constants)) {
                 Ok(parsed_program) => {
-                    let mut robot = Robot::new(robot_id, robot_name, position, center);
+                    // Create robot with seed if provided
+                    let robot_seed = seed.map(|s| s.wrapping_add(robot_id as u64));
+                    let mut robot = Robot::new(robot_id, robot_name, position, center, robot_seed);
                     robot.load_program(parsed_program);
                     robots.push(robot);
                 }
@@ -328,16 +336,19 @@ impl Game {
         self.particle_system.update(self.cycle_duration);
 
         // --- Remove destroyed robots, add obstacles, check win/draw ---
-        // This block correctly calculates and uses its own `destroyed_robots`
-        let destroyed_robots: Vec<Robot> = self
+        // Collect positions of destroyed robots before removing them
+        let destroyed_robot_positions: Vec<Point> = self
             .robots
             .iter()
             .filter(|r| r.status == RobotStatus::Destroyed)
-            .cloned()
+            .map(|r| r.position)
             .collect();
-        for robot in &destroyed_robots {
-            self.arena.add_obstacle_at_robot(robot);
+        
+        // Add obstacles at destroyed robot positions
+        for position in destroyed_robot_positions {
+            self.arena.add_obstacle_at_position(position);
         }
+        
         // Remove destroyed robots from the robots vector
         self.robots.retain(|r| r.status != RobotStatus::Destroyed);
 
@@ -399,6 +410,48 @@ impl Game {
             }
         }
     }
+
+    /// Run headless simulation without graphics for fast testing
+    pub async fn run_simulation(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Starting headless simulation...");
+
+        while self.current_turn <= self.max_turns && !self.game_over {
+            // Run a full turn (all cycles)
+            for _ in 0..config::CYCLES_PER_TURN {
+                self.update_simulation();
+                
+                // Break early if game ends mid-turn
+                if self.game_over {
+                    break;
+                }
+            }
+        }
+
+        // Report final results
+        let alive_robots: Vec<&Robot> = self
+            .robots
+            .iter()
+            .filter(|r| r.status != RobotStatus::Destroyed)
+            .collect();
+
+        match alive_robots.len() {
+            0 => info!("Simulation complete: DRAW - No survivors after {} turns", self.current_turn - 1),
+            1 => {
+                let winner = alive_robots[0];
+                info!("Simulation complete: {} WINS with {:.2} health after {} turns", 
+                      winner.name, winner.health, self.current_turn - 1);
+            }
+            _ => {
+                info!("Simulation complete: {} survivors after {} turns:", alive_robots.len(), self.current_turn - 1);
+                for robot in &alive_robots {
+                    info!("  {} - Health: {:.2}", robot.name, robot.health);
+                }
+            }
+        }
+
+        info!("Exiting headless simulation.");
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -411,7 +464,7 @@ mod tests {
     fn dummy_robot(id: u32, pos: Point, status: RobotStatus) -> Robot {
         // Use a default center for dummy robots in tests
         let center = Point { x: 0.5, y: 0.5 };
-        let mut robot = Robot::new(id, format!("TestRobot_{}", id).to_string(), pos, center);
+        let mut robot = Robot::new(id, format!("TestRobot_{}", id).to_string(), pos, center, None);
         robot.status = status;
         robot
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,14 @@ struct Args {
     /// Disable sound effects
     #[arg(long)]
     no_audio: bool,
+
+    /// Random seed for deterministic simulation (u64)
+    #[arg(long)]
+    seed: Option<u64>,
+
+    /// Run simulation without graphics (headless mode for fast testing)
+    #[arg(long)]
+    simulate: bool,
 }
 
 fn window_conf() -> Conf {
@@ -90,22 +98,15 @@ async fn main() {
 
     info!("Bot Arena starting...");
 
-    // Create Renderer and load fonts
-    let mut renderer = Renderer::new();
-    renderer.load_title_font().await; // Load title font
-    renderer.load_ui_font().await; // Load UI font
-    renderer.init_glow_resources();
-    renderer.init_scanner_material();
-
     // Create AudioManager
     let mut audio_manager = AudioManager::new();
     // Load sounds only if --no-audio is NOT specified
-    if !args.no_audio {
+    if !args.no_audio && !args.simulate {
         audio_manager.load_assets().await;
     }
 
     // Create Game instance (passing potentially empty audio_manager)
-    let mut game = match Game::new(&args.robot_files, args.max_turns, audio_manager) {
+    let mut game = match Game::new(&args.robot_files, args.max_turns, audio_manager, args.seed) {
         Ok(g) => g,
         Err(e) => {
             error!("Failed to initialize game: {}", e);
@@ -117,10 +118,26 @@ async fn main() {
         game.arena.place_obstacles();
     }
 
-    // Run the game loop
-    if let Err(e) = game.run(&mut renderer).await {
-        error!("Game loop error: {}", e);
-        process::exit(1);
+    // Run the game loop - either simulate mode or with graphics
+    if args.simulate {
+        // Headless simulation mode
+        if let Err(e) = game.run_simulation().await {
+            error!("Simulation error: {}", e);
+            process::exit(1);
+        }
+    } else {
+        // Create Renderer and load fonts (only for graphics mode)
+        let mut renderer = Renderer::new();
+        renderer.load_title_font().await; // Load title font
+        renderer.load_ui_font().await; // Load UI font
+        renderer.init_glow_resources();
+        renderer.init_scanner_material();
+
+        // Run the game loop with graphics
+        if let Err(e) = game.run(&mut renderer).await {
+            error!("Game loop error: {}", e);
+            process::exit(1);
+        }
     }
 
     info!("Bot Arena finished.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ async fn main() {
     };
 
     if !args.no_obstacles {
-        game.arena.place_obstacles();
+        game.place_obstacles();
     }
 
     // Run the game loop - either simulate mode or with graphics

--- a/src/render.rs
+++ b/src/render.rs
@@ -1288,6 +1288,24 @@ void main() {
                 instr_params.clone(),
             );
 
+            // --- Debug Register Value ---
+            let dbg_val = robot.vm_state.registers.get(Register::Dbg).unwrap_or(0.0);
+            let dbg_val_y = instr_val_y + row_v_spacing + 12.0; // Position below instruction
+            
+            // Define params for debug value text (slightly different color)
+            let dbg_params = TextParams {
+                font_size: 11,        // Even smaller font
+                color: Color::from_rgba(180, 180, 180, 255), // Slightly dimmed
+                ..small_white_params  // Inherit font
+            };
+            let dbg_text = format!("@dbg: {:.1}", dbg_val);
+            draw_text_ex(
+                &dbg_text,
+                panel_x + card_inner_padding_x,
+                dbg_val_y,
+                dbg_params,
+            );
+
             // Update main y for next card
             y += card_height + card_spacing;
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1291,12 +1291,12 @@ void main() {
             // --- Debug Register Value ---
             let dbg_val = robot.vm_state.registers.get(Register::Dbg).unwrap_or(0.0);
             let dbg_val_y = instr_val_y + row_v_spacing + 12.0; // Position below instruction
-            
+
             // Define params for debug value text (slightly different color)
             let dbg_params = TextParams {
-                font_size: 11,        // Even smaller font
+                font_size: 11,                               // Even smaller font
                 color: Color::from_rgba(180, 180, 180, 255), // Slightly dimmed
-                ..small_white_params  // Inherit font
+                ..small_white_params                         // Inherit font
             };
             let dbg_text = format!("@dbg: {:.1}", dbg_val);
             draw_text_ex(

--- a/src/robot.rs
+++ b/src/robot.rs
@@ -325,13 +325,6 @@ impl Robot {
         registers
             .set_internal(vm::registers::Register::BackwardDistance, backward_dist)
             .unwrap();
-        // Weapon related registers
-        registers
-            .set_internal(vm::registers::Register::WeaponPower, self.power)
-            .unwrap(); // Example: Use robot power
-        registers
-            .set_internal(vm::registers::Register::WeaponCooldown, 0.0)
-            .unwrap(); // Placeholder
     }
 
     /// Execute one simulation cycle's worth of VM instructions.
@@ -483,8 +476,6 @@ impl Robot {
             PosY,
             ForwardDistance,
             BackwardDistance,
-            WeaponPower,
-            WeaponCooldown,
             TargetDistance,
             TargetDirection,
         ];

--- a/src/robot.rs
+++ b/src/robot.rs
@@ -494,6 +494,7 @@ impl Robot {
             C,
             Result,
             Fault,
+            Dbg,
             Turn,
             Cycle,
             Rand,

--- a/src/robot.rs
+++ b/src/robot.rs
@@ -7,6 +7,7 @@ use crate::vm::instruction::Instruction;
 use crate::vm::parser;
 use crate::vm::state::VMState;
 use rand::prelude::*;
+use rand::RngCore;
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 
@@ -57,7 +58,6 @@ impl Default for TurretComponent {
 }
 
 // Represents a robot in the arena
-#[derive(Debug, Clone)]
 pub struct Robot {
     pub id: u32,      // Unique identifier
     pub name: String, // Name derived from filename
@@ -72,18 +72,49 @@ pub struct Robot {
     pub prev_turret_direction: f64, // <-- Add previous turret direction
     pub vm_state: VMState,          // Made public for executor access
     pub program: Vec<Instruction>,
-    pub rng: ThreadRng,
+    pub rng: Box<dyn RngCore>,
     pub aoi: Vec<u32>, // Area of interest - IDs of nearby robots
+}
+
+impl std::fmt::Debug for Robot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Robot")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("position", &self.position)
+            .field("prev_position", &self.prev_position)
+            .field("health", &self.health)
+            .field("power", &self.power)
+            .field("status", &self.status)
+            .field("drive", &self.drive)
+            .field("prev_drive_direction", &self.prev_drive_direction)
+            .field("turret", &self.turret)
+            .field("prev_turret_direction", &self.prev_turret_direction)
+            .field("vm_state", &self.vm_state)
+            .field("program", &self.program)
+            .field("rng", &"<RNG>")  // Can't debug RNG, so just show placeholder
+            .field("aoi", &self.aoi)
+            .finish()
+    }
 }
 
 impl Robot {
     // Creates a new robot with default values at a given position
-    pub fn new(id: u32, name: String, position: Point, center: Point) -> Self {
+    pub fn new(id: u32, name: String, position: Point, center: Point, seed: Option<u64>) -> Self {
         // Calculate angle towards the center
         let dx = center.x - position.x;
         let dy = center.y - position.y;
         let angle_rad = dy.atan2(dx);
         let initial_direction_deg = angle_rad.to_degrees().rem_euclid(360.0);
+
+        // Create RNG - either seeded or using thread_rng
+        let rng: Box<dyn RngCore> = if let Some(seed_value) = seed {
+            use rand::SeedableRng;
+            use rand::rngs::StdRng;
+            Box::new(StdRng::seed_from_u64(seed_value))
+        } else {
+            Box::new(thread_rng())
+        };
 
         Robot {
             id,
@@ -108,7 +139,7 @@ impl Robot {
             prev_turret_direction: initial_direction_deg, // Initialize prev state
             vm_state: VMState::new(),
             program: Vec::new(), // Initialize empty program
-            rng: thread_rng(),
+            rng,
             aoi: Vec::new(), // Initialize empty area of interest
         }
     }
@@ -927,7 +958,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, String::new(), Point { x: 1.0, y: 1.0 }, center);
+        let mut robot = Robot::new(0, String::new(), Point { x: 1.0, y: 1.0 }, center, None);
         let mut command_queue = VecDeque::new();
 
         // Print arena size
@@ -1074,7 +1105,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, String::new(), Point { x: 1.0, y: 1.0 }, center);
+        let mut robot = Robot::new(0, String::new(), Point { x: 1.0, y: 1.0 }, center, None);
         let mut command_queue = VecDeque::new();
 
         // First select drive component
@@ -1140,6 +1171,7 @@ mod tests {
             String::new(),
             Point { x: 0.5, y: 0.5 },
             Point { x: 0.5, y: 0.5 },
+            None,
         );
         let arena = Arena::default();
         let mut command_queue = VecDeque::new();
@@ -1199,6 +1231,7 @@ mod tests {
             String::new(),
             Point { x: 0.5, y: 0.5 },
             Point { x: 0.5, y: 0.5 },
+            None,
         );
         let arena = Arena::default();
         let mut command_queue = VecDeque::new();
@@ -1240,6 +1273,7 @@ mod tests {
             String::new(),
             Point { x: 0.5, y: 0.5 },
             Point { x: 0.5, y: 0.5 },
+            None,
         );
         let arena = Arena::default();
 
@@ -1268,7 +1302,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let mut command_queue = VecDeque::new();
 
         // Set up robot state
@@ -1409,6 +1443,7 @@ mod tests {
             "Test".to_string(),
             Point { x: 0.5, y: 0.5 },
             Point { x: 0.5, y: 0.5 },
+            None,
         );
         let arena = Arena::new();
         // Add a simple program if needed, e.g., MOV D0, 10

--- a/src/robot.rs
+++ b/src/robot.rs
@@ -941,7 +941,7 @@ mod tests {
         let program = parse_program(
             r#"
             select 1      ; select drive
-            drive 1.0     ; set velocity to 1.0 grid unit per turn
+            drive 0.2     ; set velocity to 0.2 normalized speed = 1.0 grid unit per turn
             rotate 0.0    ; set rotation to 0 degrees (east)
         "#,
         );
@@ -960,7 +960,8 @@ mod tests {
         // Explicitly set direction to 0 for this test, overriding center-facing default
         robot.drive.direction = 0.0;
 
-        // Expected velocity is 1.0 * UNIT_SIZE / CYCLES_PER_TURN coordinate units per cycle
+        // Expected velocity: 0.2 normalized speed * 5 grid units per turn = 1.0 grid unit per turn
+        // 1.0 grid unit per turn = 1.0 * UNIT_SIZE / CYCLES_PER_TURN coordinate units per cycle
         let expected_velocity = config::UNIT_SIZE / config::CYCLES_PER_TURN as f64;
 
         // Debug print
@@ -1049,7 +1050,7 @@ mod tests {
         // For the test, we'll check if the robot moved 1 grid unit (with a small tolerance)
         assert!(
             (distance_moved - config::UNIT_SIZE).abs() < 0.001,
-            "Robot should move {} coordinate units (1 grid unit) per turn with drive 1.0, but moved {} coordinate units",
+            "Robot should move {} coordinate units (1 grid unit) per turn with drive 0.2, but moved {} coordinate units",
             config::UNIT_SIZE,
             distance_moved
         );
@@ -1080,7 +1081,8 @@ mod tests {
         robot.vm_state.set_selected_component(1).unwrap();
 
         // Set velocity to 0.5 grid units per turn (using the Drive instruction directly)
-        let drive_instruction = Instruction::Drive(Operand::Value(0.5));
+        // In normalized system: 0.5 grid units = 0.1 normalized speed (0.5/5.0)
+        let drive_instruction = Instruction::Drive(Operand::Value(0.1));
         let processor = ComponentOperations::new();
         processor
             .process(
@@ -1092,7 +1094,8 @@ mod tests {
             )
             .unwrap();
 
-        // Expected velocity is 0.5 * UNIT_SIZE / CYCLES_PER_TURN coordinate units per cycle
+        // Expected velocity: 0.1 normalized speed * 5 grid units per turn = 0.5 grid units per turn
+        // 0.5 grid units per turn = 0.5 * UNIT_SIZE / CYCLES_PER_TURN coordinate units per cycle
         let expected_velocity = 0.5 * config::UNIT_SIZE / config::CYCLES_PER_TURN as f64;
 
         // Check if velocity was set correctly
@@ -1117,14 +1120,14 @@ mod tests {
         // Check that the robot moved ~0.025 coordinate units (0.5 grid units)
         let distance_moved = robot.position.x - start_x;
         println!(
-            "Fractional test: moved {} coordinate units ({} grid units) with drive 0.5",
+            "Fractional test: moved {} coordinate units ({} grid units) with drive 0.1",
             distance_moved,
             distance_moved / config::UNIT_SIZE
         );
 
         assert!(
             (distance_moved - 0.5 * config::UNIT_SIZE).abs() < 0.001,
-            "Robot should move {} coordinate units (0.5 grid units) per turn with drive 0.5, but moved {} coordinate units",
+            "Robot should move {} coordinate units (0.5 grid units) per turn with drive 0.1, but moved {} coordinate units",
             0.5 * config::UNIT_SIZE,
             distance_moved
         );
@@ -1144,7 +1147,7 @@ mod tests {
         let program = parse_program(
             r#"
             select 1         ; select drive
-            drive 0.5        ; set velocity
+            drive 0.1        ; set velocity (0.1 normalized = 0.5 grid units per turn)
             select 2         ; select turret
             rotate 45.0      ; set turret rotation
         "#,
@@ -1350,9 +1353,10 @@ mod tests {
         // We need the executor to process the instruction
         let executor = vm::executor::InstructionExecutor::new();
 
-        // --- Test setting velocity to 1.0 ---
-        let target_grid_velocity = 1.0;
-        let drive_instr = Instruction::Drive(Operand::Value(target_grid_velocity));
+        // --- Test setting velocity to 1.0 grid unit per turn (normalized speed 0.2) ---
+        let normalized_speed = 0.2; // 0.2 normalized = 1.0 grid unit per turn
+        let target_grid_velocity = normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN; // 0.2 * 5.0 = 1.0
+        let drive_instr = Instruction::Drive(Operand::Value(normalized_speed));
 
         // Explicitly select the Drive component (ID 1) before executing
         robot
@@ -1360,10 +1364,10 @@ mod tests {
             .set_selected_component(1)
             .expect("Failed to select drive component");
 
-        // Execute the Drive(1.0) instruction
+        // Execute the Drive(0.2) instruction
         executor
             .execute_instruction(&mut robot, &[], &arena, &drive_instr, &mut command_queue)
-            .expect("Drive(1.0) instruction execution failed");
+            .expect("Drive(0.2) instruction execution failed");
 
         // Calculate the expected velocity in coordinate units per cycle
         let expected_coord_velocity_per_cycle =

--- a/src/robot.rs
+++ b/src/robot.rs
@@ -6,8 +6,8 @@ use crate::vm;
 use crate::vm::instruction::Instruction;
 use crate::vm::parser;
 use crate::vm::state::VMState;
-use rand::prelude::*;
 use rand::RngCore;
+use rand::prelude::*;
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 
@@ -92,7 +92,7 @@ impl std::fmt::Debug for Robot {
             .field("prev_turret_direction", &self.prev_turret_direction)
             .field("vm_state", &self.vm_state)
             .field("program", &self.program)
-            .field("rng", &"<RNG>")  // Can't debug RNG, so just show placeholder
+            .field("rng", &"<RNG>") // Can't debug RNG, so just show placeholder
             .field("aoi", &self.aoi)
             .finish()
     }
@@ -1303,7 +1303,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let mut command_queue = VecDeque::new();
 
         // Set up robot state

--- a/src/vm/executor/arithmetic_ops.rs
+++ b/src/vm/executor/arithmetic_ops.rs
@@ -338,7 +338,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing
@@ -808,10 +814,22 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None);
-        
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.0, y: 0.0 },
+            center,
+            None,
+        );
+
         // Create a separate robot for the robots vector (tests typically need this for the executor)
-        let other_robot = Robot::new(1, "OtherRobot".to_string(), Point { x: 1.0, y: 1.0 }, center, None);
+        let other_robot = Robot::new(
+            1,
+            "OtherRobot".to_string(),
+            Point { x: 1.0, y: 1.0 },
+            center,
+            None,
+        );
         let robots = vec![other_robot];
         let mut q = VecDeque::new();
         let executor = InstructionExecutor::new();

--- a/src/vm/executor/arithmetic_ops.rs
+++ b/src/vm/executor/arithmetic_ops.rs
@@ -338,7 +338,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing
@@ -808,8 +808,11 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center);
-        let robots = vec![robot.clone()];
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None);
+        
+        // Create a separate robot for the robots vector (tests typically need this for the executor)
+        let other_robot = Robot::new(1, "OtherRobot".to_string(), Point { x: 1.0, y: 1.0 }, center, None);
+        let robots = vec![other_robot];
         let mut q = VecDeque::new();
         let executor = InstructionExecutor::new();
 

--- a/src/vm/executor/bitwise_ops.rs
+++ b/src/vm/executor/bitwise_ops.rs
@@ -274,7 +274,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing

--- a/src/vm/executor/bitwise_ops.rs
+++ b/src/vm/executor/bitwise_ops.rs
@@ -274,7 +274,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing

--- a/src/vm/executor/combat_ops.rs
+++ b/src/vm/executor/combat_ops.rs
@@ -144,27 +144,29 @@ mod tests {
 
     // Helper function to create a test robot
     fn create_test_robot() -> Robot {
-        let arena = Arena::new(); // Create a dummy arena to get center
+        let arena = Arena::new();
         let center = Point {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        Robot::new(
-            1,
-            "TestRobot1".to_string(),
-            Point { x: 0.5, y: 0.5 },
-            center,
-        )
+        let mut robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+
+        // Initialize some default state for testing
+        robot.health = 100.0;
+        robot.power = 1.0;
+        robot.status = RobotStatus::Active;
+
+        robot
     }
 
     // Helper function to create a test robot at a specific position
     fn create_test_robot_at(pos: Point, id: u32) -> Robot {
-        let arena = Arena::new(); // Create a dummy arena to get center
+        let arena = Arena::new();
         let center = Point {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        Robot::new(id, format!("TestRobot{}", id), pos, center)
+        Robot::new(id, format!("TestRobot{}", id), pos, center, None)
     }
 
     #[test]
@@ -242,7 +244,10 @@ mod tests {
         let other_robot_pos = Point { x: 0.7, y: 0.5 };
         let mut other_robot = create_test_robot_at(other_robot_pos, 2);
         other_robot.status = RobotStatus::Active;
-        let all_robots = vec![robot.clone(), other_robot];
+        
+        // Create a separate robot instance for the robots vector
+        let robot_for_vec = create_test_robot();
+        let all_robots = vec![robot_for_vec, other_robot];
 
         let executor = InstructionExecutor::new();
 
@@ -289,7 +294,10 @@ mod tests {
         robot.vm_state.set_selected_component(2).unwrap();
         let arena = Arena::new();
         let mut command_queue = VecDeque::new();
-        let all_robots = vec![robot.clone()];
+        
+        // Create a separate robot instance for the robots vector
+        let robot_for_vec = create_test_robot();
+        let all_robots = vec![robot_for_vec];
         let executor = InstructionExecutor::new();
 
         // Execute scan instruction
@@ -329,7 +337,10 @@ mod tests {
         let other_robot_pos = Point { x: 0.7, y: 0.5 };
         let mut other_robot = create_test_robot_at(other_robot_pos, 2);
         other_robot.status = RobotStatus::Active;
-        let robots = vec![robot.clone(), other_robot];
+        
+        // Create a separate robot instance for the robots vector
+        let robot_for_vec = create_test_robot();
+        let robots = vec![robot_for_vec, other_robot];
 
         let mut command_queue = VecDeque::new();
 

--- a/src/vm/executor/combat_ops.rs
+++ b/src/vm/executor/combat_ops.rs
@@ -149,7 +149,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            1,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
 
         // Initialize some default state for testing
         robot.health = 100.0;
@@ -244,7 +250,7 @@ mod tests {
         let other_robot_pos = Point { x: 0.7, y: 0.5 };
         let mut other_robot = create_test_robot_at(other_robot_pos, 2);
         other_robot.status = RobotStatus::Active;
-        
+
         // Create a separate robot instance for the robots vector
         let robot_for_vec = create_test_robot();
         let all_robots = vec![robot_for_vec, other_robot];
@@ -294,7 +300,7 @@ mod tests {
         robot.vm_state.set_selected_component(2).unwrap();
         let arena = Arena::new();
         let mut command_queue = VecDeque::new();
-        
+
         // Create a separate robot instance for the robots vector
         let robot_for_vec = create_test_robot();
         let all_robots = vec![robot_for_vec];
@@ -337,7 +343,7 @@ mod tests {
         let other_robot_pos = Point { x: 0.7, y: 0.5 };
         let mut other_robot = create_test_robot_at(other_robot_pos, 2);
         other_robot.status = RobotStatus::Active;
-        
+
         // Create a separate robot instance for the robots vector
         let robot_for_vec = create_test_robot();
         let robots = vec![robot_for_vec, other_robot];

--- a/src/vm/executor/component_ops.rs
+++ b/src/vm/executor/component_ops.rs
@@ -227,7 +227,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center)
+        Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None)
     }
 
     fn setup() -> (Robot, Arena, VecDeque<ArenaCommand>) {

--- a/src/vm/executor/component_ops.rs
+++ b/src/vm/executor/component_ops.rs
@@ -134,7 +134,7 @@ impl InstructionProcessor for ComponentOperations {
                 }
             }
             Instruction::Drive(op) => {
-                let val = op.get_value(&robot.vm_state)?;
+                let normalized_speed = op.get_value(&robot.vm_state)?;
                 let selected_component = robot
                     .vm_state
                     .registers
@@ -146,41 +146,42 @@ impl InstructionProcessor for ComponentOperations {
                         robot.id,
                         robot.vm_state.turn,
                         robot.vm_state.cycle,
-                        "Drive instruction. Value: {}",
-                        val
+                        "Drive instruction. Normalized speed: {}",
+                        normalized_speed
                     );
 
-                    // When user inputs drive 1.0, we want the robot to move 1.0 GRID unit per TURN
-                    // A grid unit is config::UNIT_SIZE coordinate units (0.05)
-                    // So we convert grid units to coordinate units per cycle:
-                    // grid_units * UNIT_SIZE / CYCLES_PER_TURN = coordinate_units_per_cycle
-                    let units_per_cycle = val * config::DRIVE_VELOCITY_FACTOR;
+                    // Clamp the normalized speed to 0.0-1.0 range
+                    let clamped_normalized_speed = normalized_speed.clamp(
+                        -config::MAX_DRIVE_SPEED_NORMALIZED, 
+                        config::MAX_DRIVE_SPEED_NORMALIZED
+                    );
 
-                    // Clamp to a maximum (let's say max is ±5 grid units per turn, or ±0.25 coordinate units)
-                    let max_units_per_cycle =
-                        config::MAX_DRIVE_UNITS_PER_TURN * config::DRIVE_VELOCITY_FACTOR;
-                    let clamped_velocity =
-                        units_per_cycle.clamp(-max_units_per_cycle, max_units_per_cycle);
+                    // Scale normalized speed (0.0-1.0) to actual grid units per turn (0.0-5.0)
+                    let grid_units_per_turn = clamped_normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN;
 
-                    if clamped_velocity != units_per_cycle {
+                    // Convert grid units per turn to coordinate units per cycle
+                    let units_per_cycle = grid_units_per_turn * config::DRIVE_VELOCITY_FACTOR;
+
+                    if clamped_normalized_speed != normalized_speed {
                         crate::debug_instructions!(
                             robot.id,
                             robot.vm_state.turn,
                             robot.vm_state.cycle,
-                            "Drive velocity clamped from {} to {} coordinate units per cycle",
-                            units_per_cycle,
-                            clamped_velocity
+                            "Drive speed clamped from {} to {} (normalized)",
+                            normalized_speed,
+                            clamped_normalized_speed
                         );
                     }
 
-                    robot.set_drive_velocity(clamped_velocity);
+                    robot.set_drive_velocity(units_per_cycle);
                     crate::debug_instructions!(
                         robot.id,
                         robot.vm_state.turn,
                         robot.vm_state.cycle,
-                        "Drive instruction set velocity to {} units per cycle ({} units per turn)",
+                        "Drive instruction set velocity to {} units per cycle ({} grid units per turn, normalized speed {})",
                         robot.drive.velocity,
-                        robot.drive.velocity * config::CYCLES_PER_TURN as f64 / config::UNIT_SIZE
+                        grid_units_per_turn,
+                        clamped_normalized_speed
                     );
 
                     // Update the velocity register to reflect the new target velocity
@@ -349,19 +350,21 @@ mod tests {
         // Select drive component first
         robot.vm_state.set_selected_component(1).unwrap();
 
-        // Test with a value within the allowed range
-        let drive_velocity = 0.5;
-        let expected_scaled_velocity = drive_velocity * config::DRIVE_VELOCITY_FACTOR;
-        let drive = Instruction::Drive(Operand::Value(drive_velocity));
+        // Test with a normalized speed within the allowed range (0.0-1.0)
+        let normalized_speed = 0.5; // 50% of max speed
+        let expected_grid_units_per_turn = normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN; // 0.5 * 5.0 = 2.5
+        let expected_scaled_velocity = expected_grid_units_per_turn * config::DRIVE_VELOCITY_FACTOR;
+        let drive = Instruction::Drive(Operand::Value(normalized_speed));
         let result = processor.process(&mut robot, &[], &arena, &drive, &mut command_queue);
 
         assert!(result.is_ok());
         assert_eq!(robot.drive.velocity, expected_scaled_velocity);
 
-        // Test with a value exceeding the maximum
-        let excessive_velocity = config::MAX_DRIVE_UNITS_PER_TURN + 1.0;
-        let expected_max = config::MAX_DRIVE_UNITS_PER_TURN * config::DRIVE_VELOCITY_FACTOR; // This is now 5 * UNIT_SIZE / CYCLES_PER_TURN
-        let drive_excessive = Instruction::Drive(Operand::Value(excessive_velocity));
+        // Test with a value exceeding the maximum (should be clamped to 1.0)
+        let excessive_speed = 1.5; // 150% of max speed, should be clamped to 1.0
+        let expected_max_grid_units = config::MAX_DRIVE_UNITS_PER_TURN; // 5.0 grid units per turn
+        let expected_max_velocity = expected_max_grid_units * config::DRIVE_VELOCITY_FACTOR;
+        let drive_excessive = Instruction::Drive(Operand::Value(excessive_speed));
         let result = processor.process(
             &mut robot,
             &[],
@@ -372,14 +375,13 @@ mod tests {
 
         assert!(result.is_ok());
         // Verify that the value was clamped to max
-        assert_eq!(robot.drive.velocity, expected_max);
+        assert_eq!(robot.drive.velocity, expected_max_velocity);
 
-        // Test with a value lower than the minimum
-        let excessive_reverse_velocity = -1.0 * (config::MAX_DRIVE_UNITS_PER_TURN + 1.0);
-        let expected_min =
-            -1.0 * (config::MAX_DRIVE_UNITS_PER_TURN * config::DRIVE_VELOCITY_FACTOR);
-        let reverse_drive_excessive =
-            Instruction::Drive(Operand::Value(excessive_reverse_velocity));
+        // Test with a value lower than the minimum (should be clamped to -1.0)
+        let excessive_reverse_speed = -1.5; // -150% of max speed, should be clamped to -1.0
+        let expected_min_grid_units = -config::MAX_DRIVE_UNITS_PER_TURN; // -5.0 grid units per turn
+        let expected_min_velocity = expected_min_grid_units * config::DRIVE_VELOCITY_FACTOR;
+        let reverse_drive_excessive = Instruction::Drive(Operand::Value(excessive_reverse_speed));
         let result = processor.process(
             &mut robot,
             &[],
@@ -389,8 +391,8 @@ mod tests {
         );
 
         assert!(result.is_ok());
-        // Verify that the value was clamped to max
-        assert_eq!(robot.drive.velocity, expected_min);
+        // Verify that the value was clamped to min
+        assert_eq!(robot.drive.velocity, expected_min_velocity);
     }
 
     #[test]
@@ -457,9 +459,9 @@ mod tests {
         assert_eq!(result.unwrap_err(), VMFault::NoComponentSelected);
     }
 
-    #[test] // Make this a test function
+    #[test]
     fn test_drive_velocity_conversion() {
-        let mut robot = create_test_robot(); // Helper now creates robot, needs mut
+        let mut robot = create_test_robot();
         let mut command_queue = VecDeque::new();
         let arena = Arena::new();
         let processor = ComponentOperations::new();
@@ -467,19 +469,29 @@ mod tests {
         // Select drive component first
         robot.vm_state.set_selected_component(1).unwrap();
 
-        // Test with a value within the allowed range
-        let drive_velocity = 0.5;
-        let expected_scaled_velocity = drive_velocity * config::DRIVE_VELOCITY_FACTOR;
-        let drive = Instruction::Drive(Operand::Value(drive_velocity));
+        // Test with normalized speed 0.5 (50% of max)
+        let normalized_speed = 0.5;
+        let expected_grid_units_per_turn = normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN; // 0.5 * 5.0 = 2.5
+        let expected_velocity = expected_grid_units_per_turn * config::DRIVE_VELOCITY_FACTOR;
+        let drive = Instruction::Drive(Operand::Value(normalized_speed));
         let result = processor.process(&mut robot, &[], &arena, &drive, &mut command_queue);
 
         assert!(result.is_ok());
-        assert_eq!(robot.drive.velocity, expected_scaled_velocity);
+        assert_eq!(robot.drive.velocity, expected_velocity);
 
-        // Test with a value exceeding the maximum
-        let excessive_velocity = config::MAX_DRIVE_UNITS_PER_TURN + 1.0;
-        let expected_max = config::MAX_DRIVE_UNITS_PER_TURN * config::DRIVE_VELOCITY_FACTOR; // This is now 5 * UNIT_SIZE / CYCLES_PER_TURN
-        let drive_excessive = Instruction::Drive(Operand::Value(excessive_velocity));
+        // Test with normalized speed 1.0 (100% of max)
+        let max_normalized_speed = 1.0;
+        let expected_max_grid_units = config::MAX_DRIVE_UNITS_PER_TURN; // 5.0 grid units per turn
+        let expected_max_velocity = expected_max_grid_units * config::DRIVE_VELOCITY_FACTOR;
+        let drive_max = Instruction::Drive(Operand::Value(max_normalized_speed));
+        let result = processor.process(&mut robot, &[], &arena, &drive_max, &mut command_queue);
+
+        assert!(result.is_ok());
+        assert_eq!(robot.drive.velocity, expected_max_velocity);
+
+        // Test with excessive normalized speed (should be clamped to 1.0)
+        let excessive_speed = 2.0;
+        let drive_excessive = Instruction::Drive(Operand::Value(excessive_speed));
         let result = processor.process(
             &mut robot,
             &[],
@@ -489,25 +501,7 @@ mod tests {
         );
 
         assert!(result.is_ok());
-        // Verify that the value was clamped to max
-        assert_eq!(robot.drive.velocity, expected_max);
-
-        // Test with a value lower than the minimum
-        let excessive_reverse_velocity = -1.0 * (config::MAX_DRIVE_UNITS_PER_TURN + 1.0);
-        let expected_min =
-            -1.0 * (config::MAX_DRIVE_UNITS_PER_TURN * config::DRIVE_VELOCITY_FACTOR);
-        let reverse_drive_excessive =
-            Instruction::Drive(Operand::Value(excessive_reverse_velocity));
-        let result = processor.process(
-            &mut robot,
-            &[],
-            &arena,
-            &reverse_drive_excessive,
-            &mut command_queue,
-        );
-
-        assert!(result.is_ok());
-        // Verify that the value was clamped to max
-        assert_eq!(robot.drive.velocity, expected_min);
+        // Should be clamped to max (same as 1.0 normalized speed)
+        assert_eq!(robot.drive.velocity, expected_max_velocity);
     }
 }

--- a/src/vm/executor/component_ops.rs
+++ b/src/vm/executor/component_ops.rs
@@ -152,12 +152,13 @@ impl InstructionProcessor for ComponentOperations {
 
                     // Clamp the normalized speed to 0.0-1.0 range
                     let clamped_normalized_speed = normalized_speed.clamp(
-                        -config::MAX_DRIVE_SPEED_NORMALIZED, 
-                        config::MAX_DRIVE_SPEED_NORMALIZED
+                        -config::MAX_DRIVE_SPEED_NORMALIZED,
+                        config::MAX_DRIVE_SPEED_NORMALIZED,
                     );
 
                     // Scale normalized speed (0.0-1.0) to actual grid units per turn (0.0-5.0)
-                    let grid_units_per_turn = clamped_normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN;
+                    let grid_units_per_turn =
+                        clamped_normalized_speed * config::MAX_DRIVE_UNITS_PER_TURN;
 
                     // Convert grid units per turn to coordinate units per cycle
                     let units_per_cycle = grid_units_per_turn * config::DRIVE_VELOCITY_FACTOR;
@@ -227,7 +228,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None)
+        Robot::new(
+            1,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        )
     }
 
     fn setup() -> (Robot, Arena, VecDeque<ArenaCommand>) {

--- a/src/vm/executor/control_flow_ops.rs
+++ b/src/vm/executor/control_flow_ops.rs
@@ -297,7 +297,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize the result register for conditional jumps
@@ -315,7 +315,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center);
+        let robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None);
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
     }

--- a/src/vm/executor/control_flow_ops.rs
+++ b/src/vm/executor/control_flow_ops.rs
@@ -316,7 +316,6 @@ mod tests {
             y: arena.height / 2.0,
         };
         let robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center);
-        // robot.vm_state.sp = 1024; // TODO: SP access needs update if required
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
     }

--- a/src/vm/executor/control_flow_ops.rs
+++ b/src/vm/executor/control_flow_ops.rs
@@ -297,7 +297,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize the result register for conditional jumps
@@ -315,7 +321,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None);
+        let robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.0, y: 0.0 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
     }

--- a/src/vm/executor/instruction_executor.rs
+++ b/src/vm/executor/instruction_executor.rs
@@ -127,6 +127,7 @@ mod tests {
             "TestRobot0".to_string(),
             Point { x: 0.5, y: 0.5 },
             center,
+            None,
         );
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
@@ -155,6 +156,7 @@ mod tests {
             "TestRobot0".to_string(),
             Point { x: 0.5, y: 0.5 },
             center,
+            None,
         );
         let mut command_queue = VecDeque::new();
 
@@ -188,6 +190,7 @@ mod tests {
             "TestRobot0".to_string(),
             Point { x: 0.5, y: 0.5 },
             center,
+            None,
         );
         let mut command_queue = VecDeque::new();
 

--- a/src/vm/executor/misc_ops.rs
+++ b/src/vm/executor/misc_ops.rs
@@ -42,12 +42,20 @@ impl InstructionProcessor for MiscellaneousOperations {
                 // Get the value to debug from the operand
                 let val = op.get_value(&robot.vm_state)?;
 
-                // Log the debug value
+                // Set the @dbg register to the debug value
+                robot
+                    .vm_state
+                    .registers
+                    .set_internal(crate::vm::registers::Register::Dbg, val)
+                    .unwrap();
+
+                // Log the debug value with @dbg value included
                 crate::debug_instructions!(
                     robot.id,
                     robot.vm_state.turn,
                     robot.vm_state.cycle,
-                    "DBG instruction: {}",
+                    "DBG instruction: {} (@dbg={})",
+                    val,
                     val
                 );
 

--- a/src/vm/executor/misc_ops.rs
+++ b/src/vm/executor/misc_ops.rs
@@ -86,7 +86,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
     }

--- a/src/vm/executor/misc_ops.rs
+++ b/src/vm/executor/misc_ops.rs
@@ -94,7 +94,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let robot = Robot::new(
+            1,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
         (robot, arena, command_queue)
     }

--- a/src/vm/executor/register_ops.rs
+++ b/src/vm/executor/register_ops.rs
@@ -127,7 +127,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing
@@ -352,7 +358,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         }; // Calculate center
-        let mut robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None); // Pass center
+        let mut robot = Robot::new(
+            1,
+            "TestRobot".to_string(),
+            Point { x: 0.0, y: 0.0 },
+            center,
+            None,
+        ); // Pass center
         let empty_robots = Vec::new();
         let executor = InstructionExecutor::new();
 

--- a/src/vm/executor/register_ops.rs
+++ b/src/vm/executor/register_ops.rs
@@ -127,7 +127,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing
@@ -352,7 +352,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         }; // Calculate center
-        let mut robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center); // Pass center
+        let mut robot = Robot::new(1, "TestRobot".to_string(), Point { x: 0.0, y: 0.0 }, center, None); // Pass center
         let empty_robots = Vec::new();
         let executor = InstructionExecutor::new();
 

--- a/src/vm/executor/stack_ops.rs
+++ b/src/vm/executor/stack_ops.rs
@@ -93,7 +93,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize stack and registers for testing

--- a/src/vm/executor/stack_ops.rs
+++ b/src/vm/executor/stack_ops.rs
@@ -93,7 +93,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize stack and registers for testing

--- a/src/vm/executor/trig_ops.rs
+++ b/src/vm/executor/trig_ops.rs
@@ -253,7 +253,13 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
+        let mut robot = Robot::new(
+            0,
+            "TestRobot".to_string(),
+            Point { x: 0.5, y: 0.5 },
+            center,
+            None,
+        );
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing

--- a/src/vm/executor/trig_ops.rs
+++ b/src/vm/executor/trig_ops.rs
@@ -253,7 +253,7 @@ mod tests {
             x: arena.width / 2.0,
             y: arena.height / 2.0,
         };
-        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center);
+        let mut robot = Robot::new(0, "TestRobot".to_string(), Point { x: 0.5, y: 0.5 }, center, None);
         let command_queue = VecDeque::new();
 
         // Initialize registers for testing

--- a/src/vm/instruction.rs
+++ b/src/vm/instruction.rs
@@ -128,28 +128,14 @@ impl Instruction {
             // Control Flow / Subroutines
             Call(_) | Ret => 2,
 
-            // Dynamic Cost
-            Rotate(op) => {
-                match op {
-                    Operand::Value(angle) => 1 + (angle.abs() / 45.0).ceil() as u32,
-                    Operand::Register(reg) => {
-                        // Get value without mutation if possible, else use average
-                        if let Ok(angle) = vm_state.registers.get(*reg) {
-                            1 + (angle.abs() / 45.0).ceil() as u32
-                        } else {
-                            2 // Default/average if register read fails (shouldn't happen here)
-                        }
-                    }
-                }
-            }
+            // Component Operations
+            Rotate(_) => 2, // Fixed cost - just starts the rotation motor
 
             // 3 Cycles
             Fire(_) => 3,
+            Scan => 3, // Increased from 1 to 3 for better balance
 
-            // 1 Cycles
-            Scan => 1,
-
-            // 1 Cycles
+            // Dynamic Cost
             Sleep(op) => {
                 // Try to get the value from the operand, default to 1 if invalid
                 op.get_value(vm_state)

--- a/src/vm/parser.rs
+++ b/src/vm/parser.rs
@@ -1044,7 +1044,7 @@ mod tests {
     fn test_constant_expression_with_predefined_constants() {
         let mut predefined = HashMap::new();
         predefined.insert("ARENA_WIDTH".to_string(), 20.0);
-        predefined.insert("ARENA_HEIGHT".to_string(), 15.0);
+        predefined.insert("ARENA_HEIGHT".to_string(), 20.0);
         predefined.insert("PI".to_string(), PI);
 
         let source = r#"
@@ -1069,12 +1069,12 @@ mod tests {
             _ => panic!("Expected Push instruction with value 10.0"),
         }
         match &program.instructions[1] {
-            Instruction::Push(Operand::Value(v)) => assert_eq!(*v, 7.5), // 15 / 2
-            _ => panic!("Expected Push instruction with value 7.5"),
+            Instruction::Push(Operand::Value(v)) => assert_eq!(*v, 10.0), // 20 / 2
+            _ => panic!("Expected Push instruction with value 10.0"),
         }
         match &program.instructions[2] {
-            Instruction::Push(Operand::Value(v)) => assert_eq!(*v, 300.0), // 20 * 15
-            _ => panic!("Expected Push instruction with value 300.0"),
+            Instruction::Push(Operand::Value(v)) => assert_eq!(*v, 400.0), // 20 * 20
+            _ => panic!("Expected Push instruction with value 400.0"),
         }
     }
 

--- a/src/vm/parser.rs
+++ b/src/vm/parser.rs
@@ -857,6 +857,7 @@ fn parse_register(part: Option<&&str>, line: usize) -> Result<Register, ParseErr
         "@c" => Ok(C),
         "@result" => Ok(Result),
         "@fault" => Ok(Fault),
+        "@dbg" => Ok(Dbg),
         "@index" => Ok(Index),
         "@turn" => Ok(Turn),
         "@cycle" => Ok(Cycle),

--- a/src/vm/parser.rs
+++ b/src/vm/parser.rs
@@ -26,19 +26,14 @@ fn parse_constant_expression(
     constants: &HashMap<String, f64>,
     line: usize,
 ) -> Result<f64, ParseError> {
-    // First try to parse as a simple number for backward compatibility
     if let Ok(val) = expr.parse::<f64>() {
         return Ok(val);
     }
 
-    // Try to parse as a constant name
     if let Some(&val) = constants.get(expr) {
         return Ok(val);
     }
 
-    // Simple recursive descent parser for expressions
-
-    // Tokenize the expression - split by operators and parentheses while preserving them
     let expr = expr
         .replace("(", " ( ")
         .replace(")", " ) ")
@@ -50,7 +45,6 @@ fn parse_constant_expression(
 
     let tokens: Vec<&str> = expr.split_whitespace().collect();
 
-    // Define a recursive parsing function
     fn parse_expr(
         tokens: &[&str],
         pos: &mut usize,
@@ -149,16 +143,13 @@ fn parse_constant_expression(
                 }
             }
             "-" => {
-                // Unary minus
                 let val = parse_factor(tokens, pos, constants, line)?;
                 Ok(-val)
             }
             _ => {
-                // Try parsing as a number
                 if let Ok(val) = token.parse::<f64>() {
                     Ok(val)
                 } else if let Some(&val) = constants.get(token) {
-                    // Try parsing as a constant
                     Ok(val)
                 } else {
                     Err(ParseError {
@@ -880,8 +871,6 @@ fn parse_register(part: Option<&&str>, line: usize) -> Result<Register, ParseErr
         "@posy" | "@pos_y" => Ok(PosY),
         "@forwarddistance" | "@forward_distance" => Ok(ForwardDistance),
         "@backwarddistance" | "@backward_distance" => Ok(BackwardDistance),
-        "@weaponpower" | "@weapon_power" => Ok(WeaponPower),
-        "@weaponcooldown" | "@weapon_cooldown" => Ok(WeaponCooldown),
         "@targetdistance" | "@target_distance" => Ok(TargetDistance),
         "@targetdirection" | "@target_direction" => Ok(TargetDirection),
         _ => Err(ParseError {

--- a/src/vm/registers.rs
+++ b/src/vm/registers.rs
@@ -30,6 +30,7 @@ pub enum Register {
     // Special registers
     Result,
     Fault,
+    Dbg, // Debug register for tracking debug values
     // Memory index register
     Index,
     // State registers (read-only)
@@ -77,6 +78,7 @@ impl Register {
                 | Register::C
                 | Register::Result
                 | Register::Fault
+                | Register::Dbg // Debug register is writable
                 | Register::Index // Added Index register
         )
     }
@@ -91,12 +93,12 @@ impl Register {
 #[derive(Debug, Clone)]
 pub struct Registers {
     // All registers as f64 (except @c, which is i64 internally)
-    data: [f64; 42], // Increased size from 41 to 42 for Index
+    data: [f64; 43], // Increased size from 42 to 43 for Dbg
 }
 
 impl Registers {
     pub fn new() -> Self {
-        Registers { data: [0.0; 42] }
+        Registers { data: [0.0; 43] }
     }
 
     /// Get the index for a register in the data array
@@ -125,22 +127,23 @@ impl Registers {
             C => 19,
             Result => 20,
             Fault => 21,
-            Index => 22,
-            Turn => 23,
-            Cycle => 24,
-            Rand => 25,
-            Health => 26,
-            Power => 27,
-            Component => 28,
-            TurretDirection => 29,
-            DriveDirection => 30,
-            DriveVelocity => 31,
-            PosX => 32,
-            PosY => 33,
-            ForwardDistance => 34,
-            BackwardDistance => 35,
-            TargetDistance => 36,
-            TargetDirection => 37,
+            Dbg => 22,
+            Index => 23,
+            Turn => 24,
+            Cycle => 25,
+            Rand => 26,
+            Health => 27,
+            Power => 28,
+            Component => 29,
+            TurretDirection => 30,
+            DriveDirection => 31,
+            DriveVelocity => 32,
+            PosX => 33,
+            PosY => 34,
+            ForwardDistance => 35,
+            BackwardDistance => 36,
+            TargetDistance => 37,
+            TargetDirection => 38,
         }
     }
 

--- a/src/vm/registers.rs
+++ b/src/vm/registers.rs
@@ -46,11 +46,8 @@ pub enum Register {
     PosY,
     ForwardDistance,
     BackwardDistance,
-    // Weapon state registers (read-only)
-    WeaponPower,     // Current power level for weapons
-    WeaponCooldown,  // Cooldown remaining for weapons
-    TargetDistance,  // Last detected target distance
-    TargetDirection, // Last detected target angle
+    TargetDistance,
+    TargetDirection,
 }
 
 impl Register {
@@ -99,7 +96,7 @@ pub struct Registers {
 
 impl Registers {
     pub fn new() -> Self {
-        Registers { data: [0.0; 42] } // Update size
+        Registers { data: [0.0; 42] }
     }
 
     /// Get the index for a register in the data array
@@ -124,28 +121,26 @@ impl Registers {
             D15 => 15,
             D16 => 16,
             D17 => 17,
-            D18 => 18,              // Added D10-D18 indices
-            C => 19,                // Shifted C
-            Result => 20,           // Shifted Result
-            Fault => 21,            // Shifted Fault
-            Index => 22,            // New Index register
-            Turn => 23,             // Shifted Turn
-            Cycle => 24,            // Shifted Cycle
-            Rand => 25,             // Shifted Rand
-            Health => 26,           // Shifted Health
-            Power => 27,            // Shifted Power
-            Component => 28,        // Shifted Component
-            TurretDirection => 29,  // Shifted TurretDirection
-            DriveDirection => 30,   // Shifted DriveDirection
-            DriveVelocity => 31,    // Shifted DriveVelocity
-            PosX => 32,             // Shifted PosX
-            PosY => 33,             // Shifted PosY
-            ForwardDistance => 34,  // Shifted ForwardDistance
-            BackwardDistance => 35, // Shifted BackwardDistance
-            WeaponPower => 36,      // Shifted WeaponPower
-            WeaponCooldown => 37,   // Shifted WeaponCooldown
-            TargetDistance => 38,   // Shifted TargetDistance
-            TargetDirection => 39,  // Shifted TargetAngle
+            D18 => 18,
+            C => 19,
+            Result => 20,
+            Fault => 21,
+            Index => 22,
+            Turn => 23,
+            Cycle => 24,
+            Rand => 25,
+            Health => 26,
+            Power => 27,
+            Component => 28,
+            TurretDirection => 29,
+            DriveDirection => 30,
+            DriveVelocity => 31,
+            PosX => 32,
+            PosY => 33,
+            ForwardDistance => 34,
+            BackwardDistance => 35,
+            TargetDistance => 36,
+            TargetDirection => 37,
         }
     }
 
@@ -274,14 +269,6 @@ mod tests {
             Err(RegisterError::ReadOnlyRegister)
         );
         assert_eq!(
-            regs.set(Register::WeaponPower, 1.0),
-            Err(RegisterError::ReadOnlyRegister)
-        );
-        assert_eq!(
-            regs.set(Register::WeaponCooldown, 1.0),
-            Err(RegisterError::ReadOnlyRegister)
-        );
-        assert_eq!(
             regs.set(Register::TargetDistance, 1.0),
             Err(RegisterError::ReadOnlyRegister)
         );
@@ -294,7 +281,7 @@ mod tests {
     #[test]
     fn test_internal_set_works() {
         let mut regs = Registers::new();
-        for i in 0..39 {
+        for i in 0..37 {
             // Find a register that maps to this index (a bit hacky, assumes contiguous)
             // This is just for testing internal_set, not a robust way to iterate registers
             let reg = match i {
@@ -333,12 +320,10 @@ mod tests {
                 32 => Register::PosY,
                 33 => Register::ForwardDistance,
                 34 => Register::BackwardDistance,
-                35 => Register::WeaponPower,
-                36 => Register::WeaponCooldown,
-                37 => Register::TargetDistance,
-                38 => Register::TargetDirection,
+                35 => Register::TargetDistance,
+                36 => Register::TargetDirection,
                 _ => panic!(
-                    "Index out of bounds for register mapping in test ({} / 39)",
+                    "Index out of bounds for register mapping in test ({} / 37)",
                     i
                 ),
             };


### PR DESCRIPTION
Adds functionality to simulate the game without having to run it. This is much faster making it easier to iterate over bot improvements. Also added --seed option to set the random seed for consistent results.

Example:
```bash
❯ cargo run -- bots/jojo.rasm bots/jojo.rasm --max-turns 2000 --seed 1337 --simulate
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/botarena bots/jojo.rasm bots/jojo.rasm --max-turns 2000 --seed 1337 --simulate`
15:11:39.980 INFO  botarena: Bot Arena starting...
15:11:39.981 INFO  botarena::game: Arena created with 20x20 grid.
15:11:39.981 INFO  botarena::game: Simulating for a maximum of 2000 turns.
15:11:39.981 INFO  botarena::game: Using deterministic seed: 1337
15:11:39.981 INFO  [R01] botarena::game: Loading and parsing program for Robot 1 (Name: jojo) from file: bots/jojo.rasm
15:11:39.982 INFO  [R02] botarena::game: Loading and parsing program for Robot 2 (Name: jojo) from file: bots/jojo.rasm
15:11:39.985 INFO  botarena::game: Loaded 2 robots.
15:11:39.986 INFO  botarena::game: Particle system initialized.
15:11:39.986 INFO  botarena::arena: Placing 4 obstacles...
15:11:39.986 INFO  botarena::arena: Obstacles placed.
15:11:39.986 INFO  botarena::game: Starting headless simulation...
15:11:40.024 INFO  [R01] botarena::arena: Robot 1 took 6.30 damage, health remaining: 93.70
15:11:40.073 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 83.70
15:11:40.097 INFO  [R02] botarena::arena: Robot 2 took 6.30 damage, health remaining: 93.70
15:11:40.109 INFO  [R02] botarena::arena: Robot 2 took 6.30 damage, health remaining: 87.40
15:11:40.110 INFO  [R02] botarena::arena: Robot 2 took 6.30 damage, health remaining: 81.10
15:11:40.121 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 73.70
15:11:40.130 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 63.70
15:11:40.130 INFO  [R01] botarena::arena: Robot 1 took 6.30 damage, health remaining: 57.40
15:11:40.135 INFO  [R01] botarena::arena: Robot 1 took 6.30 damage, health remaining: 51.10
15:11:40.136 INFO  [R01] botarena::arena: Robot 1 took 6.30 damage, health remaining: 44.80
15:11:40.139 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 34.80
15:11:40.149 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 24.80
15:11:40.152 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 14.80
15:11:40.156 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: 4.80
15:11:40.160 INFO  [R01] botarena::arena: Robot 1 took 10.00 damage, health remaining: -5.20
15:11:40.160 INFO  [R01] botarena::arena: Robot 1 destroyed!
15:11:40.160 INFO  botarena::game: Simulation complete: jojo WINS with 81.10 health after 444 turns
15:11:40.160 INFO  botarena::game: Exiting headless simulation.
15:11:40.160 INFO  botarena: Bot Arena finished.
```
This should be the same every time it runs and it should also be the same if run without `--simulate`.